### PR TITLE
Fixed a syntax error in blueiris.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,13 @@ RUN \
  apt-key add Release.key && \
  apt-add-repository https://dl.winehq.org/wine-builds/ubuntu/ && \
  apt-get update && \
- apt-get -y install --install-recommends winehq-stable wine-mono wine-gecko
+ apt-get -y install --allow-unauthenticated --install-recommends winehq-devel wine-mono wine-gecko
 
 RUN \
  cd /usr/bin/ && \
  wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks && \
  chmod +x winetricks && \
- sh winetricks corefonts
+ sh winetricks corefonts wininet
 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 ADD blueiris.sh /root/blueiris.sh

--- a/blueiris.sh
+++ b/blueiris.sh
@@ -11,7 +11,7 @@ fi
 chown -R root:root /root/prefix32
 
 if [ ! -e "$BLUEIRIS_EXE" ] ; then
-    if [ ! -e "$INSTALL_EXE"] ; then
+    if [ ! -e "$INSTALL_EXE" ] ; then
         wget http://blueirissoftware.com/blueiris.exe
     fi
     wine blueiris.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-


### PR DESCRIPTION
* Fixed some missing whitespace in `blueiris.sh` - probably the root cause of https://github.com/jshridha/docker-blueiris/issues/2
* Switched to `winehq-devel` to pickup latest wine changes