### PR TITLE
Update to fix failing, stale build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV LANGUAGE en_US.UTF-8
 ENV WINEPREFIX /root/prefix
 ENV DISPLAY :0
 ENV BLUEIRIS_VERSION=5
+ENV RESOLUTION=1024x768x24
 
 RUN apt-get update && \ 
     apt-get install -y wget gnupg software-properties-common winbind python cifs-utils unzip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
- 
 FROM ubuntu:focal
 
 ENV HOME /root
@@ -12,14 +11,14 @@ ENV DISPLAY :0
 ENV BLUEIRIS_VERSION=5
 
 RUN apt-get update && \ 
-    apt-get install -y wget gnupg software-properties-common winbind
+    apt-get install -y wget gnupg software-properties-common winbind python cifs-utils
 
 RUN dpkg --add-architecture i386 && \
     wget -nc https://dl.winehq.org/wine-builds/winehq.key && \
     apt-key add winehq.key && \
     apt-add-repository https://dl.winehq.org/wine-builds/ubuntu/
     
-RUN apt-get update && apt-get -y install xvfb x11vnc xdotool wget tar supervisor winehq-stable net-tools fluxbox cabextract cifs-utils python
+RUN apt-get update && apt-get -y install xvfb x11vnc xdotool wget tar supervisor winehq-stable net-tools fluxbox cabextract
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 WORKDIR /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV WINEPREFIX /root/prefix32
 ENV WINEARCH win32
 ENV DISPLAY :0
 ENV BLUEIRIS_VERSION=5
+ENV RESOLUTION=1024x768x24
 
 RUN apt-get update && \ 
     apt-get install -y wget gnupg software-properties-common winbind python cifs-utils unzip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
  
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 ENV HOME /root
 ENV DEBIAN_FRONTEND noninteractive
@@ -19,12 +19,12 @@ RUN dpkg --add-architecture i386 && \
     apt-key add winehq.key && \
     apt-add-repository https://dl.winehq.org/wine-builds/ubuntu/
     
-RUN apt-get update && apt-get -y install xvfb x11vnc xdotool wget tar supervisor winehq-stable net-tools fluxbox cabextract
+RUN apt-get update && apt-get -y install xvfb x11vnc xdotool wget tar supervisor winehq-stable net-tools fluxbox cabextract cifs-utils python
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 WORKDIR /root/
-RUN wget -O - https://github.com/novnc/noVNC/archive/v1.1.0.tar.gz | tar -xzv -C /root/ && mv /root/noVNC-1.1.0 /root/novnc && ln -s /root/novnc/vnc_lite.html /root/novnc/index.html
-RUN wget -O - https://github.com/novnc/websockify/archive/v0.8.0.tar.gz | tar -xzv -C /root/ && mv /root/websockify-0.8.0 /root/novnc/utils/websockify
+RUN wget -O - https://github.com/novnc/noVNC/archive/v1.2.0.tar.gz | tar -xzv -C /root/ && mv /root/noVNC-1.2.0 /root/novnc && ln -s /root/novnc/vnc_lite.html /root/novnc/index.html
+RUN wget -O - https://github.com/novnc/websockify/archive/v0.9.0.tar.gz | tar -xzv -C /root/ && mv /root/websockify-0.9.0 /root/novnc/utils/websockify
 
 EXPOSE 8080
 # Configure user nobody to match unRAID's settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV DISPLAY :0
 ENV BLUEIRIS_VERSION=5
 
 RUN apt-get update && \ 
-    apt-get install -y wget gnupg software-properties-common winbind python cifs-utils
+    apt-get install -y wget gnupg software-properties-common winbind python cifs-utils unzip
 
 RUN dpkg --add-architecture i386 && \
     wget -nc https://dl.winehq.org/wine-builds/winehq.key && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-ENV WINEPREFIX /root/prefix32
-ENV WINEARCH win32
+ENV WINEPREFIX /root/prefix
 ENV DISPLAY :0
 ENV BLUEIRIS_VERSION=5
-ENV RESOLUTION=1024x768x24
 
 RUN apt-get update && \ 
     apt-get install -y wget gnupg software-properties-common winbind python cifs-utils unzip
@@ -44,8 +42,8 @@ RUN \
  chmod +x winetricks && \
  sh winetricks corefonts wininet
 
-RUN mv /root/prefix32 /root/prefix32_original && \
-    mkdir /root/prefix32
+RUN mv /root/prefix /root/prefix_original && \
+    mkdir /root/prefix
 
 # Expose Port
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ## docker-blueiris
 
-This is a Container for BlueIris based on [jshridha/docker-blueiris](https://github.com/jshridha/docker-blueiris)
-
-This also bumps the resolution up to 1920x1080 by default and limits the STDOUT logging.  This is a WIP as I learn more about WINE and blueiris.
+This is a Container for BlueIris based on [solarkennedy/wine-x11-novnc-docker
+](https://github.com/solarkennedy/wine-x11-novnc-docker)
 
 This container runs:
 
@@ -21,10 +20,12 @@ docker run -d \
   -p 81:81 \
   -v /path/to/data:/root/prefix32:rw \
   --log-opt max-size=5m --log-opt max-file=2 \
-  leonowski/docker-blueiris
+  jshridha/blueiris
   ```
 
-* The "/path/to/data" can be a docker volume or a local path.  It's probably best to use a local path on your host so you can drop things in it if you need to.  I also included cifs-utils so you can mount cifs from inside the container (note:  You will have to run the container privileged to be able to mount cifs)
+* The "/path/to/data" can be a docker volume or a local path.  It's probably best to use a local path on your host so you can drop things in it if you need to.  Also included is cifs-utils so you can mount cifs from inside the container (note:  You will have to run the container privileged to be able to mount cifs)
+
+* Example docker run also has log output size limited.  This will help the container storage layer from getting out of control.
 
 ## Advanced Options
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ docker run -d \
 BlueIris version 5 is supported by default. If you'd like to run BlueIris 4, set the environmental variable:
 ```BLUEIRIS_VERISION=4```
 
+The default resolution is 1024x768x24. If you need to change the resolution set the environmental variable:
+`RESOLUTION=1920x1080x24` or `RESOLUTION=1440x768x24` etc
 
 # Known Issues:
 * Saving and restoring settings backup via the BlueIris interface does not work!

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ BlueIris version 5 is supported by default. If you'd like to run BlueIris 4, set
 
 # Known Issues:
 * Saving and restoring settings backup via the BlueIris interface does not work!
-* Another issue is that the UI3 interface (served on port 80) does not get extracted.  You can grab the UI3 files from a Windows installation and copy them to the container manually.
+* Another issue is that the UI3 interface (served on port 81 by default) does not get extracted by the installer.  unzip package is added to image to extract the ui3.zip file after installation.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## docker-blueiris
 
-This is a Container for BlueIris based on [solarkennedy/wine-x11-novnc-docker
-](https://github.com/solarkennedy/wine-x11-novnc-docker)
+This is a Container for BlueIris based on [jshridha/docker-blueiris](https://github.com/jshridha/docker-blueiris)
+
+This also bumps the resolution up to 1920x1080 by default and limits the STDOUT logging.  This is a WIP as I learn more about WINE and blueiris.
 
 This container runs:
 
@@ -19,8 +20,10 @@ docker run -d \
   -p 5900:5900 \
   -p 81:81 \
   -v /path/to/data:/root/prefix32:rw \
-  jshridha/blueiris
+  leonowski/docker-blueiris
   ```
+
+* The "/path/to/data" can be a docker volume or a local path.  It's probably best to use a local path on your host so you can drop things in it if you need to.  I also included cifs-utils so you can mount cifs from inside the container (note:  You will have to run the container privileged to be able to mount cifs)
 
 ## Advanced Options
 
@@ -30,3 +33,4 @@ BlueIris version 5 is supported by default. If you'd like to run BlueIris 4, set
 
 # Known Issues:
 * Saving and restoring settings backup via the BlueIris interface does not work!
+* Another issue is that the UI3 interface (served on port 80) does not get extracted.  You can grab the UI3 files from a Windows installation and copy them to the container manually.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ This container runs:
 ```
 docker run -d \
   --name="blueiris" \
+  --privileged \
   -p 8080:8080 \
   -p 5900:5900 \
   -p 81:81 \
-  -v /path/to/data:/root/prefix32:rw \
+  -v /path/to/data:/root/prefix:rw \
   --log-opt max-size=5m --log-opt max-file=2 \
   jshridha/blueiris
   ```
@@ -26,6 +27,8 @@ docker run -d \
 * The "/path/to/data" can be a docker volume or a local path.  It's probably best to use a local path on your host so you can drop things in it if you need to.  Also included is cifs-utils so you can mount cifs from inside the container (note:  You will have to run the container privileged to be able to mount cifs)
 
 * Example docker run also has log output size limited.  This will help the container storage layer from getting out of control.
+
+* **NOTE:** The container must be run in privileged mode for the first run to allow installation of the Visual C++ components. The privileged flag can be removed after the first run.
 
 ## Advanced Options
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ This container runs:
 
 ```
 docker run -d \
-  --name="BlueIris" \
+  --name="blueiris" \
   -p 8080:8080 \
   -p 5900:5900 \
   -p 81:81 \
   -v /path/to/data:/root/prefix32:rw \
+  --log-opt max-size=5m --log-opt max-file=2 \
   leonowski/docker-blueiris
   ```
 

--- a/blueiris.sh
+++ b/blueiris.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-BLUEIRIS_EXE="/root/prefix32/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}/BlueIris.exe"
-BLUEIRIS_INSTALL_PATH="/root/prefix32/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}"
-PREFIX_DIR="/root/prefix32"
+BLUEIRIS_EXE="/root/prefix/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}/BlueIris.exe"
+BLUEIRIS_INSTALL_PATH="/root/prefix/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}"
+PREFIX_DIR="/root/prefix"
 INSTALL_EXE="/root/blueiris.exe"
 
 if [ ! -d "$PREFIX_DIR/drive_c" ]; then
-    mv /root/prefix32_original/* /root/prefix32
+    mv /root/prefix_original/* /root/prefix
 fi
 
-chown -R root:root /root/prefix32
+chown -R root:root /root/prefix
 
 if [ ! -e "$BLUEIRIS_EXE" ] ; then
     if [ ! -e "$INSTALL_EXE" ] ; then

--- a/blueiris.sh
+++ b/blueiris.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 BLUEIRIS_EXE="/root/prefix32/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}/BlueIris.exe"
+BLUEIRIS_INSTALL_PATH="/root/prefix32/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}"
 PREFIX_DIR="/root/prefix32"
 INSTALL_EXE="/root/blueiris.exe"
 
@@ -20,6 +21,9 @@ if [ ! -e "$BLUEIRIS_EXE" ] ; then
     fi
     wine blueiris.exe
     rm blueiris.exe
+    if [ "$BLUEIRIS_VERSION" == "5" ]; then
+       unzip "${BLUEIRIS_INSTALL_PATH}/ui3.zip" -d "${BLUEIRIS_INSTALL_PATH}/www/"
+    fi
 fi
 
 wine "$BLUEIRIS_EXE"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,36 +2,41 @@
 nodaemon=true
 
 [program:X11]
-command=/usr/bin/Xvfb :0 -screen 0 1024x768x24
+command=/usr/bin/Xvfb :0 -screen 0 1920x768x24
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=1MB
 redirect_stderr=true
+stdout_logfile_backups=0
 
 [program:x11vnc]
 command=/usr/bin/x11vnc
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=1MB
 redirect_stderr=true
+stdout_logfile_backups=0
 
 [program:novnc]
 command=/root/novnc/utils/launch.sh --vnc localhost:5900 --listen 8080
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=1MB
 redirect_stderr=true
+stdout_logfile_backups=0
 
 [program:fluxbox]
 command=/usr/bin/fluxbox
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=1MB
 redirect_stderr=true
+stdout_logfile_backups=0
 
 [program:blueiris]
 command=bash "/root/blueiris.sh"
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=1MB
 redirect_stderr=true
+stdout_logfile_backups=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,41 +2,36 @@
 nodaemon=true
 
 [program:X11]
-command=/usr/bin/Xvfb :0 -screen 0 1920x768x24
+command=/usr/bin/Xvfb :0 -screen 0 1920x1080x24
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=1MB
+stdout_logfile_maxbytes=0
 redirect_stderr=true
-stdout_logfile_backups=0
 
 [program:x11vnc]
 command=/usr/bin/x11vnc
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=1MB
+stdout_logfile_maxbytes=0
 redirect_stderr=true
-stdout_logfile_backups=0
 
 [program:novnc]
 command=/root/novnc/utils/launch.sh --vnc localhost:5900 --listen 8080
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=1MB
+stdout_logfile_maxbytes=0
 redirect_stderr=true
-stdout_logfile_backups=0
 
 [program:fluxbox]
 command=/usr/bin/fluxbox
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=1MB
+stdout_logfile_maxbytes=0
 redirect_stderr=true
-stdout_logfile_backups=0
 
 [program:blueiris]
 command=bash "/root/blueiris.sh"
 autorestart=true
 stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=1MB
+stdout_logfile_maxbytes=0
 redirect_stderr=true
-stdout_logfile_backups=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:X11]
-command=/usr/bin/Xvfb :0 -screen 0 1920x1080x24
+command=/usr/bin/Xvfb :0 -screen 0 %(ENV_RESOLUTION)s
 autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
- update to ubuntu Focal (required for latest wine package install)
- update to latest versions of novnc and websockify
- add python as Focal needs it specified.
- add cifs-utils so users can mount shares in container and thus write to network shares in BlueIris
- add unzip so we can run it in blueiris.sh and extract ui3.zip (fixes issues where ui3 doesn't work)